### PR TITLE
added toolset compatibility

### DIFF
--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -26,6 +26,7 @@ export { configureCacheCommand } from "./cache";
 export { configureSignCommand } from "./sign";
 export { configureReportCommand } from "./report";
 export { configureInspectCommand } from "./inspect";
+export { configureSetCommand } from "./set";
 
 // API v2 migration commands
 export { configureYankCommand } from "./yank";

--- a/packages/cli/src/commands/set/index.ts
+++ b/packages/cli/src/commands/set/index.ts
@@ -1,0 +1,59 @@
+/**
+ * enact set command
+ *
+ * Set the active toolset by name in ~/.enact/tools.json
+ */
+
+import type { Command } from "commander";
+import { error, success } from "../../utils";
+
+/**
+ * Handler for the set command
+ */
+async function setHandler(toolset: string): Promise<void> {
+  try {
+    const fs = require("node:fs");
+    const path = require("node:path");
+    const os = require("node:os");
+    const homeDir = os.homedir();
+    const toolsJsonPath = path.join(homeDir, ".enact", "tools.json");
+
+    if (!fs.existsSync(toolsJsonPath)) {
+      error(`tools.json not found at ${toolsJsonPath}`);
+      process.exit(1);
+    }
+
+    const toolsJson = JSON.parse(fs.readFileSync(toolsJsonPath, "utf-8"));
+
+    if (toolset === "NONE") {
+      toolsJson.activeToolset = undefined;
+      fs.writeFileSync(toolsJsonPath, JSON.stringify(toolsJson, null, 2));
+      success(`Active toolset unset in ${toolsJsonPath}`);
+      return;
+    }
+
+    if (!toolsJson.toolsets || !toolsJson.toolsets[toolset]) {
+      error(`Toolset '${toolset}' not found in tools.json`);
+      process.exit(1);
+    }
+
+    toolsJson.activeToolset = toolset;
+    fs.writeFileSync(toolsJsonPath, JSON.stringify(toolsJson, null, 2));
+    success(`Active toolset set to '${toolset}' in ${toolsJsonPath}`);
+  } catch (err) {
+    error(`Failed to set active toolset: ${err}`);
+    process.exit(1);
+  }
+}
+
+/**
+ * Configure the set command
+ */
+export function configureSetCommand(program: Command): void {
+  program
+    .command("set <toolset>")
+    .description(
+      "Set the active toolset by name (writes to ~/.enact/tools.json). Use 'NONE' to unset."
+    )
+    .action(setHandler);
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -26,6 +26,7 @@ import {
   configureReportCommand,
   configureRunCommand,
   configureSearchCommand,
+  configureSetCommand,
   configureSetupCommand,
   configureSignCommand,
   configureTrustCommand,
@@ -54,6 +55,7 @@ async function main() {
     .version(version, "-v, --version", "output the version number");
 
   // Configure all commands
+
   configureSetupCommand(program);
   configureInitCommand(program);
   configureRunCommand(program);
@@ -85,6 +87,9 @@ async function main() {
   configureVisibilityCommand(program);
   // MCP integration commands
   configureMcpCommand(program);
+
+  // Set active toolset command
+  configureSetCommand(program);
 
   // Validation command
   configureValidateCommand(program);


### PR DESCRIPTION
Users can define toolsets in the global tools.json file (~/.enact/tools.json) in the format: {
  "tools": {
    "testuser/hello-js": "1.0.0",
    "examples/hello-simple": "0.1.0",
    "enact/test/remote-sign-demo": "0.1.1",
    "enact/context7/docs": "1.0.0",
    "enact/text-summarizer": "1.0.1",
    "enact/hello-simple": "0.1.5",
    "enact/hello-js": "1.0.2",
    "enact/hello-python": "1.0.0"
  },
  "toolsets": {
    "test": ["enact/hello-python"]
  },
  "activeToolset": "test"
}